### PR TITLE
feat: Add `secret_string` and `secret_binary` to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,10 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | The ARN of the secret |
+| <a name="output_secret_binary"></a> [secret\_binary](#output\_secret\_binary) | The secret binary |
 | <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | The ID of the secret |
 | <a name="output_secret_replica"></a> [secret\_replica](#output\_secret\_replica) | Attributes of the replica created |
+| <a name="output_secret_string"></a> [secret\_string](#output\_secret\_string) | The secret string |
 | <a name="output_secret_version_id"></a> [secret\_version\_id](#output\_secret\_version\_id) | The unique identifier of the version of the secret |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -64,10 +64,12 @@ No inputs.
 | <a name="output_rotate_secret_arn"></a> [rotate\_secret\_arn](#output\_rotate\_secret\_arn) | The ARN of the secret |
 | <a name="output_rotate_secret_id"></a> [rotate\_secret\_id](#output\_rotate\_secret\_id) | The ID of the secret |
 | <a name="output_rotate_secret_replica"></a> [rotate\_secret\_replica](#output\_rotate\_secret\_replica) | Attributes of the replica created |
+| <a name="output_rotate_secret_string"></a> [rotate\_secret\_string](#output\_rotate\_secret\_string) | The secret string |
 | <a name="output_rotate_secret_version_id"></a> [rotate\_secret\_version\_id](#output\_rotate\_secret\_version\_id) | The unique identifier of the version of the secret |
 | <a name="output_standard_secret_arn"></a> [standard\_secret\_arn](#output\_standard\_secret\_arn) | The ARN of the secret |
 | <a name="output_standard_secret_id"></a> [standard\_secret\_id](#output\_standard\_secret\_id) | The ID of the secret |
 | <a name="output_standard_secret_replica"></a> [standard\_secret\_replica](#output\_standard\_secret\_replica) | Attributes of the replica created |
+| <a name="output_standard_secret_string"></a> [standard\_secret\_string](#output\_standard\_secret\_string) | The secret string |
 | <a name="output_standard_secret_version_id"></a> [standard\_secret\_version\_id](#output\_standard\_secret\_version\_id) | The unique identifier of the version of the secret |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -22,6 +22,12 @@ output "standard_secret_version_id" {
   value       = module.secrets_manager.secret_version_id
 }
 
+output "standard_secret_string" {
+  description = "The secret string"
+  sensitive   = true
+  value       = module.secrets_manager.secret_string
+}
+
 ################################################################################
 # Rotate
 ################################################################################
@@ -44,4 +50,10 @@ output "rotate_secret_replica" {
 output "rotate_secret_version_id" {
   description = "The unique identifier of the version of the secret"
   value       = module.secrets_manager_rotate.secret_version_id
+}
+
+output "rotate_secret_string" {
+  description = "The secret string"
+  sensitive   = true
+  value       = module.secrets_manager_rotate.secret_string
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,6 +17,18 @@ output "secret_replica" {
   value       = try(aws_secretsmanager_secret.this[0].replica, null)
 }
 
+output "secret_string" {
+  description = "The secret string"
+  sensitive   = true
+  value       = try(aws_secretsmanager_secret_version.this[0].secret_string, aws_secretsmanager_secret_version.ignore_changes[0].secret_string, null)
+}
+
+output "secret_binary" {
+  description = "The secret binary"
+  sensitive   = true
+  value       = try(aws_secretsmanager_secret_version.this[0].secret_binary, aws_secretsmanager_secret_version.ignore_changes[0].secret_binary, null)
+}
+
 ################################################################################
 # Version
 ################################################################################

--- a/wrappers/outputs.tf
+++ b/wrappers/outputs.tf
@@ -1,5 +1,5 @@
 output "wrapper" {
   description = "Map of outputs of a wrapper."
   value       = module.wrapper
-  # sensitive = false # No sensitive module output found
+  sensitive   = true # At least one sensitive module output (secret_string) found (requires Terraform 0.14+)
 }


### PR DESCRIPTION
## Description
Add `secret_string` and `secret_binary` to outputs. 

## Motivation and Context
Closes: https://github.com/terraform-aws-modules/terraform-aws-secrets-manager/issues/7

## Breaking Changes
No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
