### PR TITLE
feat: Add `secret_name` to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ No modules.
 | <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | The ARN of the secret |
 | <a name="output_secret_binary"></a> [secret\_binary](#output\_secret\_binary) | The secret binary |
 | <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | The ID of the secret |
+| <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | The name of the secret |
 | <a name="output_secret_replica"></a> [secret\_replica](#output\_secret\_replica) | Attributes of the replica created |
 | <a name="output_secret_string"></a> [secret\_string](#output\_secret\_string) | The secret string |
 | <a name="output_secret_version_id"></a> [secret\_version\_id](#output\_secret\_version\_id) | The unique identifier of the version of the secret |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -68,6 +68,7 @@ No inputs.
 | <a name="output_rotate_secret_version_id"></a> [rotate\_secret\_version\_id](#output\_rotate\_secret\_version\_id) | The unique identifier of the version of the secret |
 | <a name="output_standard_secret_arn"></a> [standard\_secret\_arn](#output\_standard\_secret\_arn) | The ARN of the secret |
 | <a name="output_standard_secret_id"></a> [standard\_secret\_id](#output\_standard\_secret\_id) | The ID of the secret |
+| <a name="output_standard_secret_name"></a> [standard\_secret\_id](#output\_standard\_secret\_name) | The Name of the secret |
 | <a name="output_standard_secret_replica"></a> [standard\_secret\_replica](#output\_standard\_secret\_replica) | Attributes of the replica created |
 | <a name="output_standard_secret_string"></a> [standard\_secret\_string](#output\_standard\_secret\_string) | The secret string |
 | <a name="output_standard_secret_version_id"></a> [standard\_secret\_version\_id](#output\_standard\_secret\_version\_id) | The unique identifier of the version of the secret |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -68,7 +68,7 @@ No inputs.
 | <a name="output_rotate_secret_version_id"></a> [rotate\_secret\_version\_id](#output\_rotate\_secret\_version\_id) | The unique identifier of the version of the secret |
 | <a name="output_standard_secret_arn"></a> [standard\_secret\_arn](#output\_standard\_secret\_arn) | The ARN of the secret |
 | <a name="output_standard_secret_id"></a> [standard\_secret\_id](#output\_standard\_secret\_id) | The ID of the secret |
-| <a name="output_standard_secret_name"></a> [standard\_secret\_id](#output\_standard\_secret\_name) | The Name of the secret |
+| <a name="output_standard_secret_name"></a> [standard\_secret\_name](#output\_standard\_secret\_name) | The Name of the secret |
 | <a name="output_standard_secret_replica"></a> [standard\_secret\_replica](#output\_standard\_secret\_replica) | Attributes of the replica created |
 | <a name="output_standard_secret_string"></a> [standard\_secret\_string](#output\_standard\_secret\_string) | The secret string |
 | <a name="output_standard_secret_version_id"></a> [standard\_secret\_version\_id](#output\_standard\_secret\_version\_id) | The unique identifier of the version of the secret |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -68,7 +68,7 @@ No inputs.
 | <a name="output_rotate_secret_version_id"></a> [rotate\_secret\_version\_id](#output\_rotate\_secret\_version\_id) | The unique identifier of the version of the secret |
 | <a name="output_standard_secret_arn"></a> [standard\_secret\_arn](#output\_standard\_secret\_arn) | The ARN of the secret |
 | <a name="output_standard_secret_id"></a> [standard\_secret\_id](#output\_standard\_secret\_id) | The ID of the secret |
-| <a name="output_standard_secret_name"></a> [standard\_secret\_name](#output\_standard\_secret\_name) | The Name of the secret |
+| <a name="output_standard_secret_name"></a> [standard\_secret\_name](#output\_standard\_secret\_name) | The name of the secret |
 | <a name="output_standard_secret_replica"></a> [standard\_secret\_replica](#output\_standard\_secret\_replica) | Attributes of the replica created |
 | <a name="output_standard_secret_string"></a> [standard\_secret\_string](#output\_standard\_secret\_string) | The secret string |
 | <a name="output_standard_secret_version_id"></a> [standard\_secret\_version\_id](#output\_standard\_secret\_version\_id) | The unique identifier of the version of the secret |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -12,6 +12,11 @@ output "standard_secret_id" {
   value       = module.secrets_manager.secret_id
 }
 
+output "standard_secret_name" {
+  description = "The name of the secret"
+  value       = module.secrets_manager.secret_name
+}
+
 output "standard_secret_replica" {
   description = "Attributes of the replica created"
   value       = module.secrets_manager.secret_replica

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,6 +12,11 @@ output "secret_id" {
   value       = try(aws_secretsmanager_secret.this[0].id, null)
 }
 
+output "secret_name" {
+  description = "The name of the secret"
+  value       = try(aws_secretsmanager_secret.this[0].name, null)
+}
+
 output "secret_replica" {
   description = "Attributes of the replica created"
   value       = try(aws_secretsmanager_secret.this[0].replica, null)


### PR DESCRIPTION
## Description
secret name will be outputted 

## Motivation and Context
When the AWS glue connection is created, we need the secret name. I tried with a secret ID, and neither worked. 
## Breaking Changes
This would print an additional output, and doesn't break anything

## How Has This Been Tested?
- [yes] created a secret with this fork and outputted the secret name. 
- The only detected change was an output with secret_name
- [yes] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
