### PR TITLE
feat: Allow secret value to be not created

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,56 @@ module "secrets_manager" {
 }
 ```
 
+### Secret Manager Secret without any secret value ( string or binary ) created
+
+```hcl
+module "secrets_manager" {
+  source = "terraform-aws-modules/secrets-manager/aws"
+
+  # Secret
+  name_prefix             = "rotated-example"
+  description             = "Rotated example Secrets Manager secret"
+  recovery_window_in_days = 7
+
+  # Policy
+  create_policy       = true
+  block_public_policy = true
+  policy_statements = {
+    lambda = {
+      sid = "LambdaReadWrite"
+      principals = [{
+        type        = "AWS"
+        identifiers = ["arn:aws:iam:1234567890:role/lambda-function"]
+      }]
+      actions = [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecretVersionStage",
+      ]
+      resources = ["*"]
+    }
+    read = {
+      sid = "AllowAccountRead"
+      principals = [{
+        type        = "AWS"
+        identifiers = ["arn:aws:iam::1234567890:root"]
+      }]
+      actions   = ["secretsmanager:DescribeSecret"]
+      resources = ["*"]
+    }
+  }
+
+  # Version
+  create_secret_string = false
+
+  tags = {
+    Environment = "Development"
+    Project     = "Example"
+  }
+}
+```
+
 ## Examples
 
 Examples codified under the [`examples`](https://github.com/terraform-aws-modules/terraform-aws-secrets-manager/tree/master/examples) are intended to give users references for how to use the module(s) as well as testing/validating changes to the source code of the module. If contributing to the project, please be sure to make any appropriate updates to the relevant examples to allow maintainers to test your changes and to keep the examples up to date for users. Thank you!
@@ -158,6 +208,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Determines whether a policy will be created | `bool` | `false` | no |
 | <a name="input_create_random_password"></a> [create\_random\_password](#input\_create\_random\_password) | Determines whether a random password will be generated | `bool` | `false` | no |
+| <a name="input_create_secret_value"></a> [create\_secret\_value](#input\_create\_secret\_value) | Determines whether a secret value (string or binary) will be created. Default is `true`. If you wish to create a secret without an initial value, set this to `false` | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the secret | `string` | `null` | no |
 | <a name="input_enable_rotation"></a> [enable\_rotation](#input\_enable\_rotation) | Determines whether secret rotation is enabled | `bool` | `false` | no |
 | <a name="input_force_overwrite_replica_secret"></a> [force\_overwrite\_replica\_secret](#input\_force\_overwrite\_replica\_secret) | Accepts boolean value to specify whether to overwrite a secret with the same name in the destination Region | `bool` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ module "secrets_manager" {
   }
 
   # Version
-  create_secret_string = false
+  create_secret_value = false
 
   tags = {
     Environment = "Development"

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -45,6 +45,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | ../.. | n/a |
 | <a name="module_secrets_manager_disabled"></a> [secrets\_manager\_disabled](#module\_secrets\_manager\_disabled) | ../.. | n/a |
 | <a name="module_secrets_manager_rotate"></a> [secrets\_manager\_rotate](#module\_secrets\_manager\_rotate) | ../.. | n/a |
+| <a name="module_secrets_manager_without_any_initial_value"></a> [secrets\_manager\_without\_any\_initial\_value](#module\_secrets\_manager\_without\_any\_initial\_value) | ../.. | n/a |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -123,6 +123,12 @@ module "secrets_manager_disabled" {
   create = false
 }
 
+module "secrets_manager_without_any_initial_value" {
+  source = "../.."
+
+  create_secret_value = false
+}
+
 ################################################################################
 # Supporting Resources
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ resource "aws_secretsmanager_secret_policy" "this" {
 ################################################################################
 
 resource "aws_secretsmanager_secret_version" "this" {
-  count = var.create && !(var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
+  count = var.create && var.create_secret_value && !(var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
 
   secret_id      = aws_secretsmanager_secret.this[0].id
   secret_string  = var.create_random_password ? random_password.this[0].result : var.secret_string
@@ -99,7 +99,7 @@ resource "aws_secretsmanager_secret_version" "this" {
 }
 
 resource "aws_secretsmanager_secret_version" "ignore_changes" {
-  count = var.create && (var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
+  count = var.create && var.create_secret_value && (var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
 
   secret_id      = aws_secretsmanager_secret.this[0].id
   secret_string  = var.create_random_password ? random_password.this[0].result : var.secret_string

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,12 @@ variable "block_public_policy" {
 # Version
 ################################################################################
 
+variable "create_secret_value" {
+  description = "Determines whether a secret value (string or binary) will be created. Default is `true`. If you wish to create a secret without an initial value, set this to `false`"
+  type        = bool
+  default     = true
+}
+
 variable "ignore_secret_changes" {
   description = "Determines whether or not Terraform will ignore changes made externally to `secret_string` or `secret_binary`. Changing this value after creation is a destructive operation"
   type        = bool

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -7,6 +7,7 @@ module "wrapper" {
   create                           = try(each.value.create, var.defaults.create, true)
   create_policy                    = try(each.value.create_policy, var.defaults.create_policy, false)
   create_random_password           = try(each.value.create_random_password, var.defaults.create_random_password, false)
+  create_secret_value              = try(each.value.create_secret_value, var.defaults.create_secret_value, true)
   description                      = try(each.value.description, var.defaults.description, null)
   enable_rotation                  = try(each.value.enable_rotation, var.defaults.enable_rotation, false)
   force_overwrite_replica_secret   = try(each.value.force_overwrite_replica_secret, var.defaults.force_overwrite_replica_secret, null)


### PR DESCRIPTION
## Description
In some situations you'd like to create the secrets manager secret but without any value because you might want to manage the secret_version outside of terraform.
This PR allows you to create secrets_manager secrets without any initial value creation.

## Motivation and Context
I'd like to be able to use the community module with all its added functionality but without defining an initial value.

## Breaking Changes
No breaking changes, I've set the default value to `true` for the introduced variable.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
