### PR TITLE
fix: Keep support for OpenTofu

### DIFF
--- a/examples/complete/versions.tofu
+++ b/examples/complete/versions.tofu
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.8" # Without ephemeral and write-only support
 
   required_providers {
     aws = {

--- a/examples/complete/versions.tofu
+++ b/examples/complete/versions.tofu
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.7"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -100,9 +100,9 @@ resource "aws_secretsmanager_secret_version" "this" {
 
   secret_id                = aws_secretsmanager_secret.this[0].id
   secret_binary            = var.secret_binary
-  secret_string            = var.secret_string
-  secret_string_wo         = var.create_random_password ? ephemeral.random_password.this[0].result : var.secret_string_wo
-  secret_string_wo_version = var.create_random_password ? coalesce(var.secret_string_wo_version, 0) : var.secret_string_wo_version
+  secret_string            = local.secret_string
+  secret_string_wo         = local.secret_string_wo
+  secret_string_wo_version = local.secret_string_wo_version
   version_stages           = var.version_stages
 }
 
@@ -113,9 +113,9 @@ resource "aws_secretsmanager_secret_version" "ignore_changes" {
 
   secret_id                = aws_secretsmanager_secret.this[0].id
   secret_binary            = var.secret_binary
-  secret_string            = var.secret_string
-  secret_string_wo         = var.create_random_password ? ephemeral.random_password.this[0].result : var.secret_string_wo
-  secret_string_wo_version = var.create_random_password ? coalesce(var.secret_string_wo_version, 0) : var.secret_string_wo_version
+  secret_string            = local.secret_string
+  secret_string_wo         = local.secret_string_wo
+  secret_string_wo_version = local.secret_string_wo_version
   version_stages           = var.version_stages
 
   lifecycle {
@@ -127,13 +127,6 @@ resource "aws_secretsmanager_secret_version" "ignore_changes" {
   }
 }
 
-ephemeral "random_password" "this" {
-  count = var.create && var.create_random_password ? 1 : 0
-
-  length           = var.random_password_length
-  special          = true
-  override_special = var.random_password_override_special
-}
 
 ################################################################################
 # Rotation

--- a/secret_string.tf
+++ b/secret_string.tf
@@ -1,0 +1,26 @@
+locals {
+  secret_string            = var.secret_string
+  secret_string_wo         = var.create_random_password ? ephemeral.random_password.this[0].result : var.secret_string_wo
+  secret_string_wo_version = var.create_random_password ? coalesce(var.secret_string_wo_version, 0) : var.secret_string_wo_version
+}
+
+variable "secret_string_wo" {
+  description = "Specifies text data that you want to encrypt and store in this version of the secret. This is required if `secret_binary` or `secret_string` is not set"
+  type        = string
+  default     = null
+  ephemeral   = true
+}
+
+variable "secret_string_wo_version" {
+  description = "Used together with `secret_string_wo` to trigger an update. Increment this value when an update to `secret_string_wo` is required"
+  type        = string
+  default     = null
+}
+
+ephemeral "random_password" "this" {
+  count = var.create && var.create_random_password ? 1 : 0
+
+  length           = var.random_password_length
+  special          = true
+  override_special = var.random_password_override_special
+}

--- a/secret_string.tf
+++ b/secret_string.tf
@@ -4,14 +4,14 @@ locals {
   secret_string_wo_version = var.create_random_password ? coalesce(var.secret_string_wo_version, 0) : var.secret_string_wo_version
 }
 
-variable "secret_string_wo" {
+variable "secret_string_wo" { # tflint-ignore: terraform_standard_module_structure
   description = "Specifies text data that you want to encrypt and store in this version of the secret. This is required if `secret_binary` or `secret_string` is not set"
   type        = string
   default     = null
   ephemeral   = true
 }
 
-variable "secret_string_wo_version" {
+variable "secret_string_wo_version" { # tflint-ignore: terraform_standard_module_structure
   description = "Used together with `secret_string_wo` to trigger an update. Increment this value when an update to `secret_string_wo` is required"
   type        = string
   default     = null

--- a/secret_string.tofu
+++ b/secret_string.tofu
@@ -1,0 +1,13 @@
+locals {
+  secret_string            = var.create_random_password ? random_password.this[0].result : var.secret_string
+  secret_string_wo         = null # Write-only not supported in OpenTofu yet
+  secret_string_wo_version = null # Write-only not supported in OpenTofu yet
+}
+
+resource "random_password" "this" {
+  count = var.create && var.create_random_password ? 1 : 0
+
+  length           = var.random_password_length
+  special          = true
+  override_special = var.random_password_override_special
+}

--- a/variables.tf
+++ b/variables.tf
@@ -141,19 +141,6 @@ variable "secret_string" {
   default     = null
 }
 
-variable "secret_string_wo" {
-  description = "Specifies text data that you want to encrypt and store in this version of the secret. This is required if `secret_binary` or `secret_string` is not set"
-  type        = string
-  default     = null
-  ephemeral   = true
-}
-
-variable "secret_string_wo_version" {
-  description = "Used together with `secret_string_wo` to trigger an update. Increment this value when an update to `secret_string_wo` is required"
-  type        = string
-  default     = null
-}
-
 variable "version_stages" {
   description = "Specifies a list of staging labels that are attached to this version of the secret. A staging label must be unique to a single version of the secret"
   type        = list(string)

--- a/versions.tofu
+++ b/versions.tofu
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6" # Without ephemeral and write-only support
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.7"
+    }
+  }
+}

--- a/versions.tofu
+++ b/versions.tofu
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6" # Without ephemeral and write-only support
+  required_version = ">= 1.8" # Without ephemeral and write-only support
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description
Resolves #15 :
* https://github.com/terraform-aws-modules/terraform-aws-secrets-manager/issues/15

OpenTofu v1.8 supports creating .tofu files to overwrite .tf files (https://github.com/opentofu/opentofu/pull/1738).

That way, the module could support Terraform and OpenTofu at the same time.

## Motivation and Context
There is no way to run v2 of this module from `tofu<=1.10`. Especially when you want to use the new `var.region` capabilities from AWS provider v6, that is unrelated to ephemeral and write-only values but included in the same commit.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None, actually it brings back backwards compatibility

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
