### PR TITLE
feat: Allow disabling secret version creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_policy"></a> [create\_policy](#input\_create\_policy) | Determines whether a policy will be created | `bool` | `false` | no |
 | <a name="input_create_random_password"></a> [create\_random\_password](#input\_create\_random\_password) | Determines whether an ephemeral random password will be generated for `secret_string_wo` | `bool` | `false` | no |
+| <a name="input_create_secret_version"></a> [create\_secret\_version](#input\_create\_secret\_version) | Determines whether a secret version will be created | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the secret | `string` | `null` | no |
 | <a name="input_enable_rotation"></a> [enable\_rotation](#input\_enable\_rotation) | Determines whether secret rotation is enabled | `bool` | `false` | no |
 | <a name="input_force_overwrite_replica_secret"></a> [force\_overwrite\_replica\_secret](#input\_force\_overwrite\_replica\_secret) | Accepts boolean value to specify whether to overwrite a secret with the same name in the destination Region | `bool` | `null` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -45,6 +45,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | ~> 8.0 |
 | <a name="module_secrets_manager"></a> [secrets\_manager](#module\_secrets\_manager) | ../.. | n/a |
 | <a name="module_secrets_manager_disabled"></a> [secrets\_manager\_disabled](#module\_secrets\_manager\_disabled) | ../.. | n/a |
+| <a name="module_secrets_manager_no_version"></a> [secrets\_manager\_no\_version](#module\_secrets\_manager\_no\_version) | ../.. | n/a |
 | <a name="module_secrets_manager_rotate"></a> [secrets\_manager\_rotate](#module\_secrets\_manager\_rotate) | ../.. | n/a |
 
 ## Resources

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -117,6 +117,20 @@ module "secrets_manager_rotate" {
   tags = local.tags
 }
 
+module "secrets_manager_no_version" {
+  source = "../.."
+
+  # Secret
+  name_prefix             = local.name
+  description             = "Example Secrets Manager secret without version"
+  recovery_window_in_days = 0
+
+  # Version
+  create_secret_version = false
+
+  tags = local.tags
+}
+
 module "secrets_manager_disabled" {
   source = "../.."
 

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "aws_secretsmanager_secret_policy" "this" {
 ################################################################################
 
 resource "aws_secretsmanager_secret_version" "this" {
-  count = var.create && !(var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
+  count = var.create && var.create_secret_version && !(var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
 
   region = var.region
 
@@ -107,7 +107,7 @@ resource "aws_secretsmanager_secret_version" "this" {
 }
 
 resource "aws_secretsmanager_secret_version" "ignore_changes" {
-  count = var.create && (var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
+  count = var.create && var.create_secret_version && (var.enable_rotation || var.ignore_secret_changes) ? 1 : 0
 
   region = var.region
 

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,12 @@ variable "block_public_policy" {
 # Version
 ################################################################################
 
+variable "create_secret_version" {
+  description = "Determines whether a secret version will be created"
+  type        = bool
+  default     = true
+}
+
 variable "ignore_secret_changes" {
   description = "Determines whether or not Terraform will ignore changes made externally to `secret_string` or `secret_binary`. Changing this value after creation is a destructive operation"
   type        = bool


### PR DESCRIPTION
## Description
This PR adds support for disabling creation of `aws_secretsmanager_secret_version` resource.

## Motivation and Context
The `aws_secretsmanager_secret_version` resource can be problematic, because it cannot work without `secretsmanager:GetSecretValue` permission, which are not always granted with roles used for Terraform plan/apply. 

In such environment, the use of this module becomes completely prohibited, because it always creates `aws_secretsmanager_secret_version` resource.

In theory, this could be avoided by using `secret_string_wo` attribute, but there is an [unresolved bug in the AWS provider](https://github.com/hashicorp/terraform-provider-aws/issues/42383). The `aws_secretsmanager_secret_version` internally calls `GetSecretValue` even when the write-only attribute is used.

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
